### PR TITLE
[WIP]チャット画面の自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,21 +1,20 @@
 $(function(){
   function buildMessage(message){
     var content = message.content ? `<p class="message__text--content"> ${message.content} </p>` : ""
-
     var image = message.image ? `<img class="message__text--image" img src="${message.image}">` : ""
     
     var html = `<div class="message" id="${message.id}">
                   <div class="message__info">
                     <div class="message__info--user">
-                      ${message.user_name}
+                      ${message.user_name} 
                     </div>
                     <div class="message__info--date">
-                      ${message.created_at}
+                      ${message.created_at} 
                     </div>
                   </div>
                   <div class="message__text">
-                     ${content}
-                     ${image}
+                      ${content} 
+                      ${image} 
                   </div>
                 </div>`
     return html;
@@ -47,4 +46,30 @@ $(function(){
       alert('メッセージの送信に失敗しました');
     })
   });
+
+  var reloadMessages = function() {
+    if($('.messages')[0] && (window.location.href.match(/\/groups\/\d+\/messages/))){ 
+      var last_message_id = $('.message').last().data('id');
+    }else{
+      var last_message_id = 0
+    }
+
+    $.ajax({
+      url: location.href,
+      type: 'GET',
+      dataType: 'json',
+      data: {id: last_message_id},
+    })
+    .done(function(messages){
+        messages.forEach(function(message){
+          var insertHTML = buildMessage(message);
+          $('.messages').append(insertHTML);
+          $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight},'fast');
+        });         
+    })
+    .fail(function() {
+      alert("自動更新に失敗しました")
+    });
+  };
+  setInterval(reloadMessages, 5000);
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -20,7 +20,6 @@ $(function() {
                       <div class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</div>
                     </div>`
     group_users.append(add_html);
-    parseFloat(id);
     user_ids.push(id);
   }
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,11 @@
+class Api::MessagesController < ApplicationController
+  def index
+    @group = Group.find(params[:id])
+    @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json{ @new_messages = @messages.where('id > ?', params[:id]) }
+    end
+  end
+end  
+  

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,6 +4,10 @@ class MessagesController < ApplicationController
   def index
     @message = Message.new
     @messages = @group.messages.includes(:user)
+    respond_to do |format|
+      format.html
+      format.json{ @new_messages = @messages.where('id > ?', params[:id]) }
+    end
   end
 
   def create

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {id: "#{message.id}"}}
   .message__info
     .message__info--user
       = message.user.name

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @new_messages.each do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   end
 
   resources :groups, only: [:new, :create, :edit, :update] do
-    resources :messages, only: [:index, :create]
+    resources :messages, only: [:index, :create]  
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
### テキスト送信時のチャット画面の自動更新
[![Screenshot from Gyazo](https://gyazo.com/0b22f92ffe36d2faebf3554aa3b30a7c/raw)](https://gyazo.com/0b22f92ffe36d2faebf3554aa3b30a7c)

### 画像送信時のチャット画面の自動更新
[![Screenshot from Gyazo](https://gyazo.com/253018b6a4bf536286aba8cb90e833d7/raw)](https://gyazo.com/253018b6a4bf536286aba8cb90e833d7)

### 最新のメッセージが特定のグループでのみ反映されるかの確認
[![Screenshot from Gyazo](https://gyazo.com/6976916261de82d5ffadb7a4304158eb/raw)](https://gyazo.com/6976916261de82d5ffadb7a4304158eb)

## WHAT

- チャット画面で定期的に自動更新が行われ、メッセージ一覧が最新のものと同期するようにしました。

- 最新メッセージを取得時、メッセージ一覧の最下部に移動するようにしました。


## WHY

- チャット機能は掲示板とは違い、リアルタイムでのやりとりが長所であり、通常必須と考えられるため導入しました。

- リアルタイムでメッセージのやりとりをしている時いち早く更新に気づけるよう、最新のメッセージを取得した時に最下部の新しいメッセージを表示するようにしました。
